### PR TITLE
Google drive fixes

### DIFF
--- a/vfs-gcs/src/main/java/com/sshtools/vfs/gcs/GoogleFileObject.java
+++ b/vfs-gcs/src/main/java/com/sshtools/vfs/gcs/GoogleFileObject.java
@@ -84,6 +84,11 @@ public class GoogleFileObject extends AbstractFileObject<GoogleStorageFileSystem
 			}
 		}
 	}
+
+	@Override
+	protected void onChange() throws IOException {
+		this.refresh();
+	}
 	
 	@Override
 	protected long doGetContentSize() throws Exception {

--- a/vfs-googledrive/src/main/java/com/sshtools/vfs/googledrive/GDriveFileName.java
+++ b/vfs-googledrive/src/main/java/com/sshtools/vfs/googledrive/GDriveFileName.java
@@ -2,17 +2,13 @@ package com.sshtools.vfs.googledrive;
 
 import org.apache.commons.vfs2.FileName;
 import org.apache.commons.vfs2.FileType;
-import org.apache.commons.vfs2.provider.GenericFileName;
+import org.apache.commons.vfs2.provider.AbstractFileName;
 import org.apache.commons.vfs2.provider.UriParser;
 
-public class GDriveFileName extends GenericFileName {
+public class GDriveFileName extends AbstractFileName {
 
-	protected GDriveFileName(final String path, final FileType type) {
-		this(null, null, path, type);
-	}
-
-	protected GDriveFileName(String userName, String password, final String path, final FileType type) {
-		super("gdrive", "google.com", 443, 443, userName, password, path, type);
+	protected GDriveFileName(String scheme, String path, FileType type) {
+		super(scheme, path, type);
 	}
 
 	public String getContainer() {
@@ -28,7 +24,12 @@ public class GDriveFileName extends GenericFileName {
 
 	@Override
 	public FileName createName(String absPath, FileType type) {
-		return new GDriveFileName(getUserName(), getPassword(), absPath, type);
+		return new GDriveFileName(getScheme(), absPath, type);
 	}
 
+	@Override
+	protected void appendRootUri(StringBuilder buffer, boolean addPassword) {
+		buffer.append(getScheme());
+		buffer.append("://");
+	}
 }

--- a/vfs-googledrive/src/main/java/com/sshtools/vfs/googledrive/GDriveFileName.java
+++ b/vfs-googledrive/src/main/java/com/sshtools/vfs/googledrive/GDriveFileName.java
@@ -3,23 +3,11 @@ package com.sshtools.vfs.googledrive;
 import org.apache.commons.vfs2.FileName;
 import org.apache.commons.vfs2.FileType;
 import org.apache.commons.vfs2.provider.AbstractFileName;
-import org.apache.commons.vfs2.provider.UriParser;
 
 public class GDriveFileName extends AbstractFileName {
 
 	protected GDriveFileName(String scheme, String path, FileType type) {
 		super(scheme, path, type);
-	}
-
-	public String getContainer() {
-		StringBuilder bui = new StringBuilder(getPath());
-		return UriParser.extractFirstElement(bui);
-	}
-
-	public String getPathAfterContainer() {
-		StringBuilder bui = new StringBuilder(getPath());
-		UriParser.extractFirstElement(bui);
-		return bui.toString();
 	}
 
 	@Override

--- a/vfs-googledrive/src/main/java/com/sshtools/vfs/googledrive/GDriveFileNameParser.java
+++ b/vfs-googledrive/src/main/java/com/sshtools/vfs/googledrive/GDriveFileNameParser.java
@@ -19,6 +19,7 @@ public class GDriveFileNameParser extends HostFileNameParser {
 		super(443);
 	}
 
+	@Override
 	public FileName parseUri(final VfsComponentContext context, FileName base, String filename)
 			throws FileSystemException {
 		final StringBuilder name = new StringBuilder();
@@ -29,13 +30,16 @@ public class GDriveFileNameParser extends HostFileNameParser {
 		int eidx = filename.indexOf("@/");
 		if (eidx != -1) 
 			filename = filename.substring(0,  eidx + 1) + "google.com" + filename.substring(eidx + 1);
-		
+
+		String scheme;
 		try {
 			auth = extractToPath(filename, name);
 			if (auth.getUserName() == null) {
-				UriParser.extractScheme(filename, name);
+				scheme = UriParser.extractScheme(filename, name);
 				UriParser.canonicalizePath(name, 0, name.length(), this);
 				UriParser.fixSeparators(name);
+			} else {
+				scheme = auth.getScheme();
 			}
 			fileType = UriParser.normalisePath(name);
 			path = name.toString();
@@ -43,7 +47,7 @@ public class GDriveFileNameParser extends HostFileNameParser {
 				path = "/";
 			}
 		} catch (FileSystemException fse) {
-			UriParser.extractScheme(filename, name);
+			scheme = UriParser.extractScheme(filename, name);
 			UriParser.canonicalizePath(name, 0, name.length(), this);
 			UriParser.fixSeparators(name);
 			// final String rootFile = extractRootPrefix(filename, name);
@@ -51,8 +55,7 @@ public class GDriveFileNameParser extends HostFileNameParser {
 			path = name.toString();
 
 		}
-		return new GDriveFileName(auth == null ? null : auth.getUserName(), auth == null ? null : auth.getPassword(),
-				path, fileType);
+		return new GDriveFileName(scheme, path, fileType);
 	}
 
 }


### PR DESCRIPTION
Without this, Google Drive doesn't work at all. A bunch of `google.com/` are put in file names and because of that no file/folder can be resolved. 