### PR TITLE
Fix not requesting all needed data in the Dropbox provider

### DIFF
--- a/vfs-dropbox/src/main/java/com/sshtools/vfs/dropbox/DropboxClientWrapper.java
+++ b/vfs-dropbox/src/main/java/com/sshtools/vfs/dropbox/DropboxClientWrapper.java
@@ -74,7 +74,11 @@ class DropboxClientWrapper implements DropboxClient {
 		try {
 			UserAuthenticator ua = DefaultFileSystemConfigBuilder.getInstance().getUserAuthenticator(fileSystemOptions);
 			UserAuthenticationData data = ua
-					.requestAuthentication(new UserAuthenticationData.Type[] { UserAuthenticationData.PASSWORD });
+					.requestAuthentication(new UserAuthenticationData.Type[] {
+						UserAuthenticationData.USERNAME,
+						UserAuthenticationData.PASSWORD,
+						UserAuthenticationData.DOMAIN
+					});
 			if (data == null) {
 				throw new Exception("vfs.provider.sftp/authentication-cancelled.error");
 			}


### PR DESCRIPTION
Without that, the Dropbox provider throws NullPointerException and is unusable.

cc @ludup 